### PR TITLE
Enhance duration parsing and update dependencies to 0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "assert_cmd"
@@ -144,24 +138,23 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -169,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -181,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -736,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -979,7 +972,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -1013,12 +1006,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1027,7 +1026,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1079,7 +1078,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "doit"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,20 @@ license = "MIT"
 repository = "https://github.com/matsuokashuhei/doit"
 
 [dependencies]
-clap = { version = "4.5.45", features = ["derive", "string"] }
-chrono = { version = "0.4.41", features = ["serde"] }
+clap = { version = "4.5.48", features = ["derive", "string"] }
+chrono = { version = "0.4.42", features = ["serde"] }
 colored = "3.0.0"
 crossterm = "0.29.0"
-anyhow = "1.0.99"
+anyhow = "1.0.100"
 thiserror = "2.0.16"
 regex = "1.11.1"
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
 predicates = "3.1.3"
-tempfile = "3.21.0"
+tempfile = "3.22.0"
 
 [profile.release]
 # Optimize for size and performance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doit"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["Shuhei Matsuoka <matsuokashuheiii@gmail.com>"]
 description = "A CLI progress monitor (doit) for time-based visualization"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -180,7 +180,7 @@ fn parse_date(s: &str) -> Result<NaiveDate, String> {
 }
 
 fn parse_duration(s: &str) -> Result<Duration, String> {
-    let re = Regex::new(r"^(\d+)([smhd])$").unwrap();
+    let re = Regex::new(r"^(\d+)([smhdy])$").unwrap();
     if let Some(caps) = re.captures(s) {
         let value = caps[1]
             .parse::<i64>()
@@ -191,6 +191,7 @@ fn parse_duration(s: &str) -> Result<Duration, String> {
             "m" => return Ok(Duration::minutes(value)),
             "h" => return Ok(Duration::hours(value)),
             "d" => return Ok(Duration::days(value)),
+            "y" => return Ok(Duration::days(value * 365)),
             _ => {}
         }
     }
@@ -204,10 +205,6 @@ fn parse_style(s: &str) -> Result<Style, String> {
 
 #[cfg(test)]
 mod tests {
-    use std::result;
-
-    use assert_cmd::assert;
-
     use super::*;
 
     #[test]
@@ -297,6 +294,17 @@ mod tests {
         assert_eq!(
             args.end.format("%Y-%m-%d %H:%M:%S").to_string(),
             "2025-01-02 10:20:30"
+        );
+    }
+
+    #[test]
+    fn test_parse_with_duration_years() {
+        let args = vec!["doit", "--start", "2025-01-01 10:20:30", "--duration", "1y"];
+        let command = build_command();
+        let args = Args::parse(command.get_matches_from(args));
+        assert_eq!(
+            args.end.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-01-01 10:20:30"
         );
     }
 


### PR DESCRIPTION
Improve duration parsing to support years and add a corresponding test case. Update the project version and dependencies in Cargo.toml and Cargo.lock.